### PR TITLE
Fix for the 'installPath' config option and typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ has ended.
 
 ### dbpath
 
-`data` - The location for `mongod` to store the database.  Defaults to the
+`dbpath` - The location for `mongod` to store the database.  Defaults to the
 `installPath + "/data"`.  This parameter is optional.
 
 ### port

--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ RapidMango.prototype.download = function download() {
 
 function RapidMango(options) {
 	options = options || {};
-	options.installPath = options.installed ||
+	options.installPath = options.installPath ||
 		path.resolve(path.dirname(module.parent.filename), "mongo");
 	options.version = options.version ||
 		"3.2.0"


### PR DESCRIPTION
Hi @og01, thanks for this cool library. I'm about to use it in one of my projects!

There were 2 things that were not as expected: 
- The installPath config parameter was not working, the code was looking for an `installed` key. 
- The README references `data` combined with `dbpath`.  
