### PR TITLE
Add stop() method to prototype to programmatically stop the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,7 +345,16 @@ RapidMango.prototype.start = function start() {
 };
 
 RapidMango.prototype.stop = function stop() {
-	this.child.kill()
+	var self = this;
+	return new Promise(function (resolve, reject) {
+		self.child.on('close', function (code) {
+			resolve(code);
+		});
+		self.child.on('error', function (err) {
+			reject(err);
+		});
+		self.child.kill();
+	})
 }
 
 module.exports = RapidMango;

--- a/index.js
+++ b/index.js
@@ -275,6 +275,8 @@ RapidMango.prototype.install = function install() {
 	});
 };
 
+var child = null;
+
 RapidMango.prototype.start = function start() {
 	var self = this;
 	return self.install().then(function () {
@@ -300,7 +302,7 @@ RapidMango.prototype.start = function start() {
 		});
 		var promise = new Promise(function (resolve, reject) {
 			self.emit("debug", "spawning: ", self.options.mongodBin, args);
-			var child = spawn(self.options.mongodBin, args, {
+			child = spawn(self.options.mongodBin, args, {
 				stdio: 'pipe'
 			});
 			child.on('error', function (code, signal) {
@@ -342,5 +344,9 @@ RapidMango.prototype.start = function start() {
 		return promise;
 	});
 };
+
+RapidMango.prototype.stop = function stop() {
+	child.kill()
+}
 
 module.exports = RapidMango;


### PR DESCRIPTION
I've hacked in a way to stop the server by running the `stop()` method on the instance. It can most likely be improved by wrapping it in a promise, but this currently serves my needs.

``` javascript
var RapidMongo = require('./index');
var rapid = new RapidMongo();

rapid.start().then(function (port) {
  console.log("Mongo is running on 127.0.0.1:" + port);
  setTimeout(function() {
    console.log("Stopping mongod after 5 seconds");
    rapid.stop();
  }, 5000)
}).catch(console.error);
```

Fixes #2 
