### PR TITLE
Add a status method to the rapid instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,4 +386,19 @@ RapidMango.prototype.stop = function stop() {
 	}).bind(this);
 };
 
+RapidMango.prototype.status = function status() {
+	var result = {
+		status: 'stopped',
+		pid: null,
+	}
+
+	if(this.child && this.child.pid) {
+		result.status = 'started'
+		result.pid = this.child.pid
+	}
+
+	return new Promise(function (resolve) {
+		resolve(result)
+	}).bind(this);
+};
 module.exports = RapidMango;


### PR DESCRIPTION
I found the need to check the status of the rapid-mongo instance so I added a prototype method for it.

``` javascript
// $ node start-stop-status.js 
var RapidMongo = require('./index')
var rapid = new RapidMongo({
  port: 27017,
})

setInterval(() => rapid.status().then(res => console.log('Status', res)), 1000)

rapid.status()
  .then(res => console.log('Status', res))
  .then(() => rapid.start())
  .then((port) => console.log(`Mongo is running on 127.0.0.1:${port}`))
  .then(() => setTimeout(() => rapid.stop(), 5000))
  .catch(console.error)
```
